### PR TITLE
add additional case statement for unknown table names

### DIFF
--- a/python/src/processing_function/lambda_function.py
+++ b/python/src/processing_function/lambda_function.py
@@ -93,7 +93,7 @@ def lambda_handler(event, context):
             case _:
                 logger.error(f"Unknown table name: {table_name}")
                 continue
-        packet_id = int(object_key.split("_")[1])
+        packet_id = int(object_key.split("_")[-2])
         processed_key = write_data_to_s3(processed_data_frames[new_table_name], new_table_name,
                                          S3_PROCESSED_BUCKET, packet_id, s3_client)
         response_data[new_table_name] = processed_key

--- a/python/src/processing_function/lambda_function.py
+++ b/python/src/processing_function/lambda_function.py
@@ -90,6 +90,9 @@ def lambda_handler(event, context):
             case "counterparty":
                 new_table_name = "dim_counterparty"
                 processed_data_frames[new_table_name] = transform_counterparty(data_frame)
+            case _:
+                logger.error(f"Unknown table name: {table_name}")
+                continue
         packet_id = int(object_key.split("_")[1])
         processed_key = write_data_to_s3(processed_data_frames[new_table_name], new_table_name,
                                          S3_PROCESSED_BUCKET, packet_id, s3_client)

--- a/python/src/processing_function/lambda_utils.py
+++ b/python/src/processing_function/lambda_utils.py
@@ -36,7 +36,7 @@ def retrieve_data(bucket_name: str, object_key: str, s3_client):
 def transform_sales_order(sales_order_df):
     """
     Transform loaded sales order data into star schema
-        - splits out time and date data into seperate columns
+        - splits out time and date data into separate columns
         - renames staff_id to sales_staff_id
         - removes unwanted columns
 
@@ -48,16 +48,24 @@ def transform_sales_order(sales_order_df):
     """
     fact_sales_order = sales_order_df.copy()
 
-    fact_sales_order['created_date'] = pd.to_datetime(fact_sales_order['created_at']).dt.date
-    fact_sales_order['created_time'] = pd.to_datetime(fact_sales_order['created_at']).dt.time
-    fact_sales_order['last_updated_date'] = \
-        pd.to_datetime(fact_sales_order['last_updated']).dt.date
-    fact_sales_order['last_updated_time'] = \
-        pd.to_datetime(fact_sales_order['last_updated']).dt.time
+    fact_sales_order['created_at'] = pd.to_datetime(
+        fact_sales_order['created_at'], errors='coerce')
+    fact_sales_order['last_updated'] = pd.to_datetime(
+        fact_sales_order['last_updated'], errors='coerce')
+    fact_sales_order['agreed_payment_date'] = pd.to_datetime(
+        fact_sales_order['agreed_payment_date'], errors='coerce')
+    fact_sales_order['agreed_delivery_date'] = pd.to_datetime(
+        fact_sales_order['agreed_delivery_date'], errors='coerce')
 
-    fact_sales_order.rename(columns={
-        'staff_id': 'sales_staff_id',
-    }, inplace=True)
+    fact_sales_order['created_date'] = fact_sales_order['created_at'].dt.date.astype(str)
+    fact_sales_order['created_time'] = fact_sales_order['created_at'].dt.time.astype(str)
+    fact_sales_order['last_updated_date'] = fact_sales_order['last_updated'].dt.date.astype(str)
+    fact_sales_order['last_updated_time'] = fact_sales_order['last_updated'].dt.time.astype(str)
+
+    fact_sales_order['agreed_payment_date'] = fact_sales_order['agreed_payment_date'].astype(str)
+    fact_sales_order['agreed_delivery_date'] = fact_sales_order['agreed_delivery_date'].astype(str)
+
+    fact_sales_order.rename(columns={'staff_id': 'sales_staff_id'}, inplace=True)
 
     return fact_sales_order[[
         'sales_order_id',
@@ -73,7 +81,8 @@ def transform_sales_order(sales_order_df):
         'design_id',
         'agreed_payment_date',
         'agreed_delivery_date',
-        'agreed_delivery_location_id']]
+        'agreed_delivery_location_id'
+    ]]
 
 
 def create_dim_date(start_date, end_date):

--- a/python/tests/processing_function/test_processing_utils.py
+++ b/python/tests/processing_function/test_processing_utils.py
@@ -192,11 +192,10 @@ class TestTransformData:
         assert result['agreed_payment_date'].iloc[0] == '2022-11-08'
         assert result['agreed_delivery_date'].iloc[0] == '2022-11-07'
         assert result['agreed_delivery_location_id'].iloc[0] == 8
-        assert result['created_date'].iloc[0] == pd.Timestamp('2022-11-03').date()
-        assert result['created_time'].iloc[0] == pd.Timestamp('14:20:52.186000').time()
-        assert result['last_updated_date'].iloc[0] == pd.Timestamp('2022-11-03').date()
-        assert result['last_updated_time'].iloc[0] == \
-            pd.Timestamp('14:20:52.186000').time()
+        assert result['created_date'].iloc[0] == '2022-11-03'
+        assert result['created_time'].iloc[0] == '14:20:52.186000'
+        assert result['last_updated_date'].iloc[0] == '2022-11-03'
+        assert result['last_updated_time'].iloc[0] == '14:20:52.186000'
 
     def test_create_dim_date(self):
         start_date = '2023-01-01'


### PR DESCRIPTION
This pull request fixes two bugs:
1) The split statement for extracting the packet id from the object key was flawed as there is an underscore in "sales_order". For that reason, I need to reference the second last element of the split string instead of the second.
2) There was an issue with writing transformed data to S3 in Parquet format due to type inference errors. The Lambda function encountered a ValueError when converting date and time columns to Parquet, due to inconsistent data types.

I have also added an additional case statement to handle unknown table names.